### PR TITLE
Update speakeasy_sdk_generation.yml

### DIFF
--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -22,5 +22,5 @@ jobs:
       publish_python: true
       mode: pr
     secrets:
-      speakeasy_api_key: ${{ secrets.SPEAKEASY_PROD_API_KEY }}
+      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
       github_access_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`secrets.SPEAKEASY_PROD_API_KEY` was renamed to `secrets.SPEAKEASY_API_KEY`, as a consolidation of secrets. 

This updates the github action in-line with respect to this change.